### PR TITLE
Add configurability & parallelism

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,23 @@ PLUGINS = [
 The next time you build your Pelican site, `pelican-minify` will automatically
 minify your Pelican pages after they've been generated.
 
+`pelican-minify` can also be configured by setting `MINIFY` to a hash containing
+[parameters to htmlmin](https://htmlmin.readthedocs.org/en/latest/reference.html#htmlmin.minify), eg:
+
+``` python
+# pelicanconf.py
+
+# ...
+
+MINIFY = {
+  'remove_comments': True,
+  'remove_all_empty_space': True,
+  'remove_optional_attribute_quotes': False
+}
+
+# ...
+```
+
 This reduces file size and obscures the public source code, but keep in
 mind--minifying your static site will increase your Pelican build times, as it
 adds extra file processing for each page generated.

--- a/minify.py
+++ b/minify.py
@@ -28,10 +28,10 @@ def minify_html(pelican):
         for name in filenames:
             if name.endswith('.html') or name.endswith('.htm'):
                 filepath = join(dirpath, name)
-                create_minified_file(filepath)
+                create_minified_file(filepath, pelican.settings.get('MINIFY', {}))
 
 
-def create_minified_file(filename):
+def create_minified_file(filename, options):
     """Create a minified HTML file, overwriting the original.
 
     :param str filename: The file to minify.
@@ -40,10 +40,7 @@ def create_minified_file(filename):
     with open(filename, 'w', encoding='utf-8') as f:
         try:
             logger.debug('Minifying: %s' % filename)
-            compressed = min(uncompressed, remove_comments=True,
-                             remove_all_empty_space=True,
-                             remove_empty_space=True,
-                             remove_optional_attribute_quotes=False)
+            compressed = min(uncompressed, **options)
             f.write(compressed)
         except Exception as ex:
             logger.critical('HTML Minification failed: %s' % ex)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
 
     # Basic package information:
     name = 'pelican-minify',
-    version = '0.8',
+    version = '0.9',
     py_modules = ('minify',),
 
     # Packaging options:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     include_package_data = True,
 
     # Package dependencies:
-    install_requires = ['htmlmin>=0.1.5', 'pelican>=3.1.1'],
+    install_requires = ['htmlmin>=0.1.5', 'pelican>=3.1.1', 'joblib>=0.9'],
 
     # Metadata for PyPI:
     author = 'Randall Degges',

--- a/tests.py
+++ b/tests.py
@@ -31,7 +31,7 @@ class TestMinify(TestCase):
             f = open(a_html_filename, 'w')
             f.write('   <html>   <head></head>  <body>hi</body>   </html>        ')
             f.close()
-            create_minified_file(a_html_filename)
+            create_minified_file(a_html_filename, { 'remove_all_empty_space': True })
             self.assertEqual(open(a_html_filename).read(), '<html><head></head><body>hi</body></html>')
 
 

--- a/tests.py
+++ b/tests.py
@@ -5,7 +5,6 @@ from unittest import TestCase, main
 
 from minify import create_minified_file
 
-
 @contextmanager
 def temporary_folder():
     """Creates a temporary folder, return it and delete it afterwards.


### PR DESCRIPTION
This pull request makes 2 enhancements to pelican-minify:
1. The minifier is configurable by setting `MINIFY` in your pelican config. The default settings in the current version of pelican-minify are unsafe and broke the theme I wrote by removing too much whitespace. Now, anyone can set it just the way they want. If no configuration is provided it defaults to the safe configuration from htmlmin, which is different from the previous version, so I bumped the version number.
2. joblib is used to parallelise file optimisation. This should provide a speedup roughly equivalent to the number of CPU cores in the machine building Pelican files (in my case with a 2-core CPU it was about 2x faster).

Per the requirements of the license, I hereby release this code into the public domain.
