### PR TITLE
Fix for python3, remove broken joblib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "2.7"
+  - "3.7"
 install:
   - python setup.py develop
 script:

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ This reduces file size and obscures the public source code, but keep in
 mind--minifying your static site will increase your Pelican build times, as it
 adds extra file processing for each page generated.
 
-**NOTE**: You should probably include the `minify` plugin at the very bottom of
-your `PLUGINS` array.  This will ensure it is the last thing to run, and
-doesn't prematurely gzip any files.
+**NOTE**: You should probably include the `minify` plugin at the very end of
+your `PLUGINS` array, but still before `gzip_cache` if you are using it.
+This will ensure it is the last thing to run, just before the results are gzipped.
 
 
 ## Changelog

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+from .minify import *

--- a/minify.py
+++ b/minify.py
@@ -1,13 +1,10 @@
 """A Pelican plugin which minifies HTML pages."""
-
-
 from logging import getLogger
 from os import walk
 from os.path import join
 
 from htmlmin import minify
 from pelican import signals
-from joblib import Parallel, delayed
 
 # We need save unicode strings to files.
 try:
@@ -29,7 +26,8 @@ def minify_html(pelican):
     for dirpath, _, filenames in walk(pelican.settings['OUTPUT_PATH']):
         files_to_minify += [join(dirpath, name) for name in filenames if name.endswith('.html') or name.endswith('.htm')]
 
-    Parallel(n_jobs=-1)(delayed(create_minified_file)(filepath, options) for filepath in files_to_minify)
+    for filepath in files_to_minify:
+        create_minified_file(filepath, options)
 
 
 def create_minified_file(filename, options):
@@ -37,7 +35,9 @@ def create_minified_file(filename, options):
 
     :param str filename: The file to minify.
     """
-    uncompressed = open(filename, encoding='utf-8').read()
+    uncompressed = ""
+    with open(filename, encoding='utf-8') as f:
+        uncompressed = f.read()
 
     with open(filename, 'w', encoding='utf-8') as f:
         try:
@@ -46,8 +46,6 @@ def create_minified_file(filename, options):
             f.write(compressed)
         except Exception as ex:
             logger.critical('HTML Minification failed: %s' % ex)
-        finally:
-            f.close()
 
 
 def register():

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     include_package_data = True,
 
     # Package dependencies:
-    install_requires = ['htmlmin>=0.1.5', 'pelican>=3.1.1', 'joblib>=0.9'],
+    install_requires = ['htmlmin>=0.1.5', 'pelican>=3.1.1'],
 
     # Metadata for PyPI:
     author = 'Randall Degges',

--- a/tests.py
+++ b/tests.py
@@ -32,7 +32,8 @@ class TestMinify(TestCase):
             f.write('   <html>   <head></head>  <body>hi</body>   </html>        ')
             f.close()
             create_minified_file(a_html_filename, {'remove_all_empty_space': True})
-            self.assertEqual(open(a_html_filename).read(), '<html><head></head><body>hi</body></html>')
+            with open(a_html_filename) as f:
+                self.assertEqual(f.read(), '<html><head></head><body>hi</body></html>')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The latest Pelican version uses Python3. This pull requests fixes `pelican-minify` to work with it.

- Added the `__init__.py` file required for the new Pelican versions.
- Removed `joblib`, as it seemed to be breaking everything.
- Modified `minify.py` and `test.py` to use Python3 file handling.
- Modified `.travis.yml` to use Python3.7.
- Fixed the wording on the gzip_cache thing.